### PR TITLE
chore cleanup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6763,14 +6763,6 @@
         "semver": "bin/semver.js"
       }
     },
-    "node_modules/vue-meta": {
-      "version": "3.0.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/vue-meta/-/vue-meta-3.0.0-alpha.9.tgz",
-      "integrity": "sha512-/ff7qNKy4c5NwmDl6N5XK2hhiXEdMeUxvk+SXCs40W9DOgu7VWGqPtgdSnXHnYMRoofkT/nKHE+vXklJ47r9Dw==",
-      "peerDependencies": {
-        "vue": "^3.0.0"
-      }
-    },
     "node_modules/vue-router": {
       "version": "4.0.12",
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.0.12.tgz",
@@ -7083,7 +7075,6 @@
         "@reeba/common": "^1.0.0",
         "postcss-import": "^14.0.2",
         "vue": "^3.0.11",
-        "vue-meta": "^3.0.0-alpha.9",
         "vue-router": "^4.0.11"
       },
       "devDependencies": {
@@ -7341,7 +7332,6 @@
         "tailwindcss": "^2.2.19",
         "vite": "^2.7.0",
         "vue": "^3.0.11",
-        "vue-meta": "3.0.0-alpha.9",
         "vue-router": "^4.0.11",
         "vue-tsc": "^0.29.8"
       }
@@ -12215,12 +12205,6 @@
           "dev": true
         }
       }
-    },
-    "vue-meta": {
-      "version": "3.0.0-alpha.9",
-      "resolved": "https://registry.npmjs.org/vue-meta/-/vue-meta-3.0.0-alpha.9.tgz",
-      "integrity": "sha512-/ff7qNKy4c5NwmDl6N5XK2hhiXEdMeUxvk+SXCs40W9DOgu7VWGqPtgdSnXHnYMRoofkT/nKHE+vXklJ47r9Dw==",
-      "requires": {}
     },
     "vue-router": {
       "version": "4.0.12",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6763,6 +6763,14 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/vue-meta": {
+      "version": "3.0.0-alpha.9",
+      "resolved": "https://registry.npmjs.org/vue-meta/-/vue-meta-3.0.0-alpha.9.tgz",
+      "integrity": "sha512-/ff7qNKy4c5NwmDl6N5XK2hhiXEdMeUxvk+SXCs40W9DOgu7VWGqPtgdSnXHnYMRoofkT/nKHE+vXklJ47r9Dw==",
+      "peerDependencies": {
+        "vue": "^3.0.0"
+      }
+    },
     "node_modules/vue-router": {
       "version": "4.0.12",
       "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-4.0.12.tgz",
@@ -7075,6 +7083,7 @@
         "@reeba/common": "^1.0.0",
         "postcss-import": "^14.0.2",
         "vue": "^3.0.11",
+        "vue-meta": "^3.0.0-alpha.9",
         "vue-router": "^4.0.11"
       },
       "devDependencies": {
@@ -7332,6 +7341,7 @@
         "tailwindcss": "^2.2.19",
         "vite": "^2.7.0",
         "vue": "^3.0.11",
+        "vue-meta": "3.0.0-alpha.9",
         "vue-router": "^4.0.11",
         "vue-tsc": "^0.29.8"
       }
@@ -12205,6 +12215,12 @@
           "dev": true
         }
       }
+    },
+    "vue-meta": {
+      "version": "3.0.0-alpha.9",
+      "resolved": "https://registry.npmjs.org/vue-meta/-/vue-meta-3.0.0-alpha.9.tgz",
+      "integrity": "sha512-/ff7qNKy4c5NwmDl6N5XK2hhiXEdMeUxvk+SXCs40W9DOgu7VWGqPtgdSnXHnYMRoofkT/nKHE+vXklJ47r9Dw==",
+      "requires": {}
     },
     "vue-router": {
       "version": "4.0.12",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "scripts": {
     "dev:backend": "cd packages/backend && npm run watch",
     "dev:frontend": "cd packages/frontend && npm run dev",
+    "dev:common": "cd packages/common && npm run watch",
     "build:backend": "cd packages/backend && npm run build",
     "build:frontend": "cd packages/frontend && npm run build",
     "build:common": "cd packages/common && npm run build"

--- a/packages/backend/nodemon.json
+++ b/packages/backend/nodemon.json
@@ -6,5 +6,5 @@
   "ignore": [
     "node_modules"
   ],
-  "exec": "npm run kill-port && npm run watch:ts-node"
+  "exec": "npm run kill-port && npm run serve:ts-node"
 }

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -8,7 +8,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/grindarius/reeba.git",
-    "directory": "backend"
+    "directory": "packages/backend"
   },
   "author": "ReebA Team",
   "scripts": {

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -16,7 +16,7 @@
     "build": "tsc -p ./tsconfig.json",
     "kill-port": "npx kill-port 3000",
     "watch": "nodemon",
-    "watch:ts-node": "ts-node src/index.ts",
+    "serve:ts-node": "ts-node src/index.ts",
     "watch:ts": "tsc -w",
     "clean": "npx rimraf dist && npx rimraf node_modules",
     "rebuild": "npm run clean && npm run watch:ts",

--- a/packages/common/nodemon.json
+++ b/packages/common/nodemon.json
@@ -1,0 +1,10 @@
+{
+  "watch": [
+    "src"
+  ],
+  "ext": "ts, js, json",
+  "ignore": [
+    "node_modules"
+  ],
+  "exec": "npm run serve:ts-node"
+}

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -14,7 +14,9 @@
   "scripts": {
     "serve": "node dist/index.js",
     "build": "tsc -p ./tsconfig.json",
+    "watch": "nodemon",
     "watch:ts": "tsc -w",
+    "serve:ts-node": "ts-node src/index.ts",
     "clean": "npx rimraf dist && npx rimraf node_modules",
     "rebuild": "npm run clean && npm run watch:ts",
     "fix": "eslint **/*.ts --fix"

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -8,7 +8,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/grindarius/reeba.git",
-    "directory": "common"
+    "directory": "packages/common"
   },
   "author": "ReebA Team",
   "scripts": {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -18,7 +18,6 @@
     "@reeba/common": "^1.0.0",
     "postcss-import": "^14.0.2",
     "vue": "^3.0.11",
-    "vue-meta": "^3.0.0-alpha.9",
     "vue-router": "^4.0.11"
   },
   "devDependencies": {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -18,6 +18,7 @@
     "@reeba/common": "^1.0.0",
     "postcss-import": "^14.0.2",
     "vue": "^3.0.11",
+    "vue-meta": "^3.0.0-alpha.9",
     "vue-router": "^4.0.11"
   },
   "devDependencies": {

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -6,7 +6,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/grindarius/reeba.git",
-    "directory": "frontend"
+    "directory": "packages/frontend"
   },
   "author": "ReebA Team",
   "scripts": {

--- a/packages/frontend/src/main.ts
+++ b/packages/frontend/src/main.ts
@@ -1,8 +1,9 @@
 import { createApp } from 'vue'
+import { createMetaManager } from 'vue-meta'
 
 import App from './App.vue'
 import Router from './router'
 
 import './globals.scss'
 
-createApp(App).use(Router).mount('#app')
+createApp(App).use(Router).use(createMetaManager()).mount('#app')

--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -6,9 +6,10 @@ import vue from '@vitejs/plugin-vue'
 export default defineConfig({
   plugins: [vue()],
   resolve: {
-    alias: {
-      '@': resolve(__dirname, 'src')
-    }
+    alias: [
+      { find: '@', replacement: resolve(__dirname, 'src') },
+      { find: '@reeba/common', replacement: resolve(__dirname, '..', 'common', 'src') }
+    ]
   },
   server: {
     port: 8080,


### PR DESCRIPTION
## ✅ DoD / งานที่ทำ

- [x] All work is complete / ทุกอย่างเรียบร้อยดี
- [x] Issues linked: None

## 📝 Summary / สรุปผล

- เขียนคำสั่งบางคำสั่งใหม่เพื่อให้มีความหมายมากขึ้น

## 💉 Testing / ทดสอบ

- คอมมานด์หลักใน root package.json ทำงานได้ปกติ

## 🛑 Problems / ปัญหา

- ลบ `vue-meta` ออกเนื่องจากปัญหา nuxt/vue-meta#693 จนกว่าปัญหานี้จะแก้ได้ เราจะไม่ใช้ `vue-meta`
- node EPERM Error ยังไม่หายไป แม้จะเปลี่ยนเป็น `ts-node` แล้ว
- พึ่งพบปัญหาว่าจริง ๆ แล้ว `vite` จะ error ถ้าเกิดว่าเรา `dev` โดยไม่มีโฟลเดอร์ `@reeba/common/dist` เพราะว่า `vite` จะทำการหา entry point ของ `dependency` จาก `package.json.main` ทีนี้ทางเข้าของเรา เข้าไปที่ `dist` แทนที่จะเป็น `src` เราจึงทำการ config `vite.config.ts` ให้ resolve alias จาก common ยังไม่แน่ใจเหมือนกันว่าวิธีนี้จะคงทนหรือไม่ หรือมีปัญหาอะไรรึเปล่า

## 💡 More ideas / ไอเดีย

ไม่มี

## 📸 Screenshots / ภาพถ่าย

ไม่มี
