### PR TITLE
adapt `POST /auth/signup` to accept phone number and country code

### DIFF
--- a/.vscode/snippets.code-snippets
+++ b/.vscode/snippets.code-snippets
@@ -68,7 +68,7 @@
       "    const response = await app.inject({$2})",
       "  } catch (error) {",
       "    t.error(error)",
-      "    t.fail('There should not be an error in a successful registration.')",
+      "    t.fail()",
       "  }",
       "})"
     ],

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "build:frontend": "cd packages/frontend && pnpm build",
     "build:common": "cd packages/common && pnpm build",
     "lint:css": "ts-node packages/scripts/src/lint-css.ts",
-    "test": "pnpm build:common && tap --rcfile=.taprc",
+    "test": "pnpm build:common && tap --rcfile=.taprc --reporter-arg=silent",
     "seed": "ts-node packages/scripts/src/seed.ts",
     "clear-uploads": "ts-node packages/scripts/src/clear-uploads-folder.ts"
   },

--- a/packages/backend/src/routes/avatars/post-avatars.ts
+++ b/packages/backend/src/routes/avatars/post-avatars.ts
@@ -63,7 +63,7 @@ export default async (instance: FastifyInstance, _: FastifyPluginOptions): Promi
         }
       } catch (error) {
         void reply.code(400)
-        throw new Error('unmatched file extension')
+        throw new Error((error as Error).message)
       }
     }
   )

--- a/packages/backend/test/auth/signin.test.ts
+++ b/packages/backend/test/auth/signin.test.ts
@@ -44,7 +44,7 @@ void t.test('signin process', async t => {
     }
   } catch (error) {
     t.error(error)
-    t.fail('Error while connecting to database')
+    t.fail()
   }
 
   void t.test('Missing email (as empty string)', async t => {
@@ -62,7 +62,7 @@ void t.test('signin process', async t => {
       t.strictSame(response.json().message, 'body should have required property \'email\'', 'Error message from missing email as empty string')
     } catch (error) {
       t.error(error)
-      t.fail('There should not be an error.')
+      t.fail()
     }
   })
 
@@ -80,7 +80,7 @@ void t.test('signin process', async t => {
       t.strictSame(response.json().message, 'body should have required property \'email\'', 'Error message from missing email as missing params')
     } catch (error) {
       t.error(error)
-      t.fail('There should not be an error.')
+      t.fail()
     }
   })
 
@@ -99,7 +99,7 @@ void t.test('signin process', async t => {
       t.strictSame(response.json().message, 'body should have required property \'password\'', 'Error message from missing password as empty string')
     } catch (error) {
       t.error(error)
-      t.fail('There should not be an error.')
+      t.fail()
     }
   })
 
@@ -117,7 +117,7 @@ void t.test('signin process', async t => {
       t.strictSame(response.json().message, 'body should have required property \'email\'', 'Error message from missing password as missing params')
     } catch (error) {
       t.error(error)
-      t.fail('There should not be an error.')
+      t.fail()
     }
   })
 
@@ -140,7 +140,7 @@ void t.test('signin process', async t => {
       t.type(response.json().verificationStatus, 'boolean', 'Type of verification status')
     } catch (error) {
       t.error(error)
-      t.fail('There should not be an error.')
+      t.fail()
     }
   })
 
@@ -158,7 +158,7 @@ void t.test('signin process', async t => {
       t.strictSame(response.json().message, '\'email\' not found')
     } catch (error) {
       t.error(error)
-      t.fail('There should not be an error.')
+      t.fail()
     }
   })
 
@@ -177,7 +177,7 @@ void t.test('signin process', async t => {
       t.strictSame(response.json().message, 'invalid \'password\'', 'response message of wrong password')
     } catch (error) {
       t.error(error)
-      t.fail('There should not be an error.')
+      t.fail()
     }
   })
 

--- a/packages/backend/test/auth/signup.test.ts
+++ b/packages/backend/test/auth/signup.test.ts
@@ -30,10 +30,10 @@ void t.test('signup process', async t => {
     await client.query('delete from "users" where user_email = \'authtest@gmail.com\'')
   } catch (error) {
     t.error(error)
-    t.fail('Error while connecting to database')
+    t.fail()
   }
 
-  void t.test('Missing username (as empty string)', async t => {
+  void t.test('missing username (as empty string)', async t => {
     try {
       const response = await app.inject({
         method: 'POST',
@@ -41,7 +41,9 @@ void t.test('signup process', async t => {
         payload: {
           username: '',
           email: 'authtest@gmail.com',
-          password: 'asdfghjkl123'
+          password: 'asdfghjkl123',
+          phoneCountryCode: '66',
+          phoneNumber: '983322552'
         }
       })
 
@@ -49,18 +51,20 @@ void t.test('signup process', async t => {
       t.strictSame(response.json().message, 'body should have required property \'username\'', 'Error message from missing username')
     } catch (error) {
       t.error(error)
-      t.fail('There should not be an error, but rather bad request')
+      t.fail()
     }
   })
 
-  void t.test('Missing username (as missing params)', async t => {
+  void t.test('missing username (as missing params)', async t => {
     try {
       const response = await app.inject({
         method: 'POST',
         url: '/auth/signup',
         payload: {
           email: 'authtest@gmail.com',
-          password: 'asdfghjkl123'
+          password: 'asdfghjkl123',
+          phoneCountryCode: '66',
+          phoneNumber: '983322552'
         }
       })
 
@@ -68,11 +72,11 @@ void t.test('signup process', async t => {
       t.strictSame(response.json().message, 'body should have required property \'username\'', 'Error message from missing username')
     } catch (error) {
       t.error(error)
-      t.fail('There should not be an error, but rather bad request')
+      t.fail()
     }
   })
 
-  void t.test('Missing email (as empty string)', async t => {
+  void t.test('missing email (as empty string)', async t => {
     try {
       const response = await app.inject({
         method: 'POST',
@@ -80,7 +84,9 @@ void t.test('signup process', async t => {
         payload: {
           username: 'grindarius',
           email: '',
-          password: 'asdfghjkl123'
+          password: 'asdfghjkl123',
+          phoneCountryCode: '66',
+          phoneNumber: '983322552'
         }
       })
 
@@ -88,18 +94,20 @@ void t.test('signup process', async t => {
       t.strictSame(response.json().message, 'body should have required property \'email\'', 'Error message from missing email')
     } catch (error) {
       t.error(error)
-      t.fail('There should not be an error, but rather bad request.')
+      t.fail()
     }
   })
 
-  void t.test('Missing email (as missing params)', async t => {
+  void t.test('missing email (as missing params)', async t => {
     try {
       const response = await app.inject({
         method: 'POST',
         url: '/auth/signup',
         payload: {
           username: 'grindarius',
-          password: 'asdfghjkl123'
+          password: 'asdfghjkl123',
+          phoneCountryCode: '66',
+          phoneNumber: '983322552'
         }
       })
 
@@ -107,11 +115,11 @@ void t.test('signup process', async t => {
       t.strictSame(response.json().message, 'body should have required property \'email\'', 'Error message from missing email')
     } catch (error) {
       t.error(error)
-      t.fail('There should not be an error, but rather bad request.')
+      t.fail()
     }
   })
 
-  void t.test('Email is not empty but wrong format', async t => {
+  void t.test('email is not empty but wrong format', async t => {
     try {
       const response = await app.inject({
         method: 'POST',
@@ -119,7 +127,9 @@ void t.test('signup process', async t => {
         payload: {
           username: 'grindarius',
           email: 'authtest @gmail.com',
-          password: 'asdfghjkl123'
+          password: 'asdfghjkl123',
+          phoneCountryCode: '66',
+          phoneNumber: '983322552'
         }
       })
 
@@ -127,11 +137,11 @@ void t.test('signup process', async t => {
       t.strictSame(response.json().message, 'invalid \'email\' format', 'Error message when email is in wrong format')
     } catch (error) {
       t.error(error)
-      t.fail('There should not be an error, but rather a normal request.')
+      t.fail()
     }
   })
 
-  void t.test('Missing password (as empty string)', async t => {
+  void t.test('missing password (as empty string)', async t => {
     try {
       const response = await app.inject({
         method: 'POST',
@@ -139,7 +149,9 @@ void t.test('signup process', async t => {
         payload: {
           username: 'grindarius',
           email: 'authtest@gmail.com',
-          password: ''
+          password: '',
+          phoneCountryCode: '66',
+          phoneNumber: '983322552'
         }
       })
 
@@ -147,30 +159,11 @@ void t.test('signup process', async t => {
       t.strictSame(response.json().message, 'body should have required property \'password\'', 'Error message when missing password')
     } catch (error) {
       t.error(error)
-      t.fail('There should not be an error, but rather a normal request.')
+      t.fail()
     }
   })
 
-  void t.test('Missing password (as missing params)', async t => {
-    try {
-      const response = await app.inject({
-        method: 'POST',
-        url: '/auth/signup',
-        payload: {
-          username: 'grindarius',
-          email: 'authtest@gmail.com'
-        }
-      })
-
-      t.strictSame(response.statusCode, 400, 'Error code when missing password')
-      t.strictSame(response.json().message, 'body should have required property \'password\'', 'Error message when missing password')
-    } catch (error) {
-      t.error(error)
-      t.fail('There should not be an error, but rather a normal request.')
-    }
-  })
-
-  void t.test('Successful signup', async t => {
+  void t.test('missing password (as missing params)', async t => {
     try {
       const response = await app.inject({
         method: 'POST',
@@ -178,7 +171,182 @@ void t.test('signup process', async t => {
         payload: {
           username: 'grindarius',
           email: 'authtest@gmail.com',
-          password: 'asdfghjkl123'
+          phoneCountryCode: '66',
+          phoneNumber: '983322552'
+        }
+      })
+
+      t.strictSame(response.statusCode, 400, 'Error code when missing password')
+      t.strictSame(response.json().message, 'body should have required property \'password\'', 'Error message when missing password')
+    } catch (error) {
+      t.error(error)
+      t.fail()
+    }
+  })
+
+  void t.test('missing phone country code (empty string)', async t => {
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/auth/signup',
+        payload: {
+          username: 'grindarius',
+          email: 'authtest@gmail.com',
+          password: 'asdfghjkl123',
+          phoneCountryCode: '',
+          phoneNumber: '9823322552'
+        }
+      })
+
+      t.strictSame(response.statusCode, 400, 'Error code when missing phone country code')
+      t.strictSame(response.json().message, 'body should have required property \'phoneCountryCode\'', 'Error message when missing phone country code')
+    } catch (error) {
+      t.error(error)
+      t.fail()
+    }
+  })
+
+  void t.test('missing phone country code (missing params)', async t => {
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/auth/signup',
+        payload: {
+          username: 'grindarius',
+          email: 'authtest@gmail.com',
+          password: 'asdfghjkl123',
+          phoneNumber: '9823322552'
+        }
+      })
+
+      t.strictSame(response.statusCode, 400, 'Error code when missing phone country code')
+      t.strictSame(response.json().message, 'body should have required property \'phoneCountryCode\'', 'Error message when missing phone country code')
+    } catch (error) {
+      t.error(error)
+      t.fail()
+    }
+  })
+
+  void t.test('missing phone number (empty string)', async t => {
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/auth/signup',
+        payload: {
+          username: 'grindarius',
+          email: 'authtest@gmail.com',
+          password: 'asdfghjkl123',
+          phoneCountryCode: '66',
+          phoneNumber: ''
+        }
+      })
+
+      t.strictSame(response.statusCode, 400, 'Error code when missing phone number')
+      t.strictSame(response.json().message, 'body should have required property \'phoneNumber\'', 'Error message when missing phone number')
+    } catch (error) {
+      t.error(error)
+      t.fail()
+    }
+  })
+
+  void t.test('missing phone number (missing params)', async t => {
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/auth/signup',
+        payload: {
+          username: 'grindarius',
+          email: 'authtest@gmail.com',
+          password: 'asdfghjkl123',
+          phoneCountryCode: '66'
+        }
+      })
+
+      t.strictSame(response.statusCode, 400, 'Error code when missing phone number')
+      t.strictSame(response.json().message, 'body should have required property \'phoneNumber\'', 'Error message when missing phone number')
+    } catch (error) {
+      t.error(error)
+      t.fail()
+    }
+  })
+
+  void t.test('wrong phone number format (includes space)', async t => {
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/auth/signup',
+        payload: {
+          username: 'grindarius',
+          email: 'authtest@gmail.com',
+          password: 'asdfghjkl123',
+          phoneCountryCode: '66',
+          phoneNumber: ' 98 23322552'
+        }
+      })
+
+      t.strictSame(response.statusCode, 400, 'Error code when phone number wrong format')
+      t.strictSame(response.json().message, 'invalid \'phoneNumber\' format', 'Error message when wrong phone number format')
+    } catch (error) {
+      t.error(error)
+      t.fail()
+    }
+  })
+
+  void t.test('wrong phone number format (includes \\n)', async t => {
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/auth/signup',
+        payload: {
+          username: 'grindarius',
+          email: 'authtest@gmail.com',
+          password: 'asdfghjkl123',
+          phoneCountryCode: '66',
+          phoneNumber: '\n43445452'
+        }
+      })
+
+      t.strictSame(response.statusCode, 400, 'Error code when phone number wrong format')
+      t.strictSame(response.json().message, 'invalid \'phoneNumber\' format', 'Error message when wrong phone number format')
+    } catch (error) {
+      t.error(error)
+      t.fail()
+    }
+  })
+
+  void t.test('wrong phone number format (includes \\t)', async t => {
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/auth/signup',
+        payload: {
+          username: 'grindarius',
+          email: 'authtest@gmail.com',
+          password: 'asdfghjkl123',
+          phoneCountryCode: '66',
+          phoneNumber: '\t43445452'
+        }
+      })
+
+      t.strictSame(response.statusCode, 400, 'Error code when phone number wrong format')
+      t.strictSame(response.json().message, 'invalid \'phoneNumber\' format', 'Error message when wrong phone number format')
+    } catch (error) {
+      t.error(error)
+      t.fail()
+    }
+  })
+
+  void t.test('successful signup', async t => {
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/auth/signup',
+        payload: {
+          username: 'grindarius',
+          email: 'authtest@gmail.com',
+          password: 'asdfghjkl123',
+          phoneCountryCode: '66',
+          phoneNumber: '9823322552'
         }
       })
 
@@ -186,24 +354,48 @@ void t.test('signup process', async t => {
       t.strictSame(response.json().message, 'complete', 'response message from signup.')
     } catch (error) {
       t.error(error)
-      t.fail('There should not be an error in a successful registration.')
+      t.fail()
     }
   })
 
-  void t.test('Duplicate signup', async t => {
+  void t.test('duplicate email signup', async t => {
+    try {
+      const response = await app.inject({
+        method: 'POST',
+        url: '/auth/signup',
+        payload: {
+          username: 'grindarius2',
+          email: 'authtest@gmail.com',
+          password: 'asdfghjkl123',
+          phoneCountryCode: '66',
+          phoneNumber: '9823322552'
+        }
+      })
+
+      t.strictSame(response.statusCode, 400, 'Error code from redundant email.')
+      t.strictSame(response.json().message, 'duplicate \'email\'', 'Error message from redundant email.')
+    } catch (error) {
+      t.error(error)
+      t.fail()
+    }
+  })
+
+  void t.test('duplicate username signup', async t => {
     try {
       const response = await app.inject({
         method: 'POST',
         url: '/auth/signup',
         payload: {
           username: 'grindarius',
-          email: 'authtest@gmail.com',
-          password: 'asdfghjkl123'
+          email: 'authtest2@gmail.com',
+          password: 'asdfghjkl123',
+          phoneCountryCode: '66',
+          phoneNumber: '9823322552'
         }
       })
 
-      t.strictSame(response.statusCode, 400, 'Error code from redundant email.')
-      t.strictSame(response.json().message, 'duplicate \'email\'', 'Error message from redundant email.')
+      t.strictSame(response.statusCode, 400, 'Error code from redundant username.')
+      t.strictSame(response.json().message, 'duplicate \'username\'', 'Error message from redundant username.')
     } catch (error) {
       t.error(error)
       t.fail('There should not be an error in a successful registration.')
@@ -218,7 +410,9 @@ void t.test('signup process', async t => {
         payload: {
           username: 'longgggggggggggggggggggggggggggggggggggggggg',
           email: 'authtest@gmail.com',
-          password: 'asdfghjkl123'
+          password: 'asdfghjkl123',
+          phoneCountryCode: '66',
+          phoneNumber: '9823322552'
         }
       })
 
@@ -226,7 +420,7 @@ void t.test('signup process', async t => {
       t.strictSame(response.json().message, 'invalid \'username\' format', 'Error message from invalid username.')
     } catch (error) {
       t.error(error)
-      t.fail('There should not be an error in a successful registration.')
+      t.fail()
     }
   })
 

--- a/packages/backend/test/avatars/get-avatar.test.ts
+++ b/packages/backend/test/avatars/get-avatar.test.ts
@@ -57,7 +57,7 @@ void t.test('get image', async t => {
     })
   } catch (error) {
     t.error(error)
-    t.fail('Error while connecting to database')
+    t.fail()
   }
 
   void t.test('get default user image when emptystring is passed', async t => {
@@ -73,7 +73,7 @@ void t.test('get image', async t => {
       })
     } catch (error) {
       t.error(error)
-      t.fail('There should not be an error')
+      t.fail()
     }
   })
 
@@ -91,7 +91,7 @@ void t.test('get image', async t => {
         })
     } catch (error) {
       t.error(error)
-      t.fail('There should not be an error')
+      t.fail()
     }
   })
 
@@ -109,7 +109,7 @@ void t.test('get image', async t => {
         })
     } catch (error) {
       t.error(error)
-      t.fail('There should not be an error')
+      t.fail()
     }
   })
 
@@ -127,7 +127,7 @@ void t.test('get image', async t => {
         })
     } catch (error) {
       t.error(error)
-      t.fail('There should not be an error in a successful registration.')
+      t.fail()
     }
   })
 })

--- a/packages/backend/test/avatars/post-avatar.test.ts
+++ b/packages/backend/test/avatars/post-avatar.test.ts
@@ -46,7 +46,7 @@ void t.test('post image', async t => {
     }
   } catch (error) {
     t.error(error)
-    t.fail('Error while connecting to database')
+    t.fail()
   }
 
   void t.test('passing empty string as username', async t => {
@@ -60,7 +60,7 @@ void t.test('post image', async t => {
       t.strictSame(response.json().message, 'params should have required property \'username\'', 'error message')
     } catch (error) {
       t.error(error)
-      t.fail('There should not be an error')
+      t.fail()
     }
   })
 
@@ -75,7 +75,7 @@ void t.test('post image', async t => {
       t.strictSame(response.json().message, 'user not found', 'error message')
     } catch (error) {
       t.error(error)
-      t.fail('There should not be an error')
+      t.fail()
     }
   })
 
@@ -95,7 +95,7 @@ void t.test('post image', async t => {
       t.strictSame(response.json().message, 'complete', 'message from posting image')
     } catch (error) {
       t.error(error)
-      t.fail('There should not be an error')
+      t.fail()
     }
   })
 
@@ -115,7 +115,7 @@ void t.test('post image', async t => {
       t.strictSame(response.json().message, 'unmatched file extension', 'message from posting unmatched file extension')
     } catch (error) {
       t.error(error)
-      t.fail('There should not be an error')
+      t.fail()
     }
   })
 })

--- a/packages/common/src/constants/regexp.ts
+++ b/packages/common/src/constants/regexp.ts
@@ -16,3 +16,10 @@ export const usernameRegExp: RegExp = /^(?=.{0,30}$)[a-zA-Z0-9_-]+$/
  * @see https://stackoverflow.com/a/374956/12386405
  */
 export const fileExtensionMatchRegExp: RegExp = /^.*\.(jpg|JPG|png|PNG|jpeg|JPEG)$/
+
+/**
+ * RegExp to match plain `n` digit phone number without spacebar
+ *
+ * @see https://www.quora.com/What-is-maximum-and-minimum-length-of-any-mobile-number-across-the-world
+ */
+export const phoneNumberRegExp: RegExp = /^\d{4,15}$/

--- a/packages/common/src/types/auth.ts
+++ b/packages/common/src/types/auth.ts
@@ -22,7 +22,9 @@ export type SigninReplyBody = Static<typeof SigninReplyBodySchema>
 export const SignupBodySchema = Type.Object({
   username: Type.String(),
   email: Type.String(),
-  password: Type.String()
+  password: Type.String(),
+  phoneCountryCode: Type.String(),
+  phoneNumber: Type.String()
 })
 export type SignupBody = Static<typeof SignupBodySchema>
 

--- a/packages/common/src/utils/validities.ts
+++ b/packages/common/src/utils/validities.ts
@@ -1,4 +1,4 @@
-import { emailRegExp, fileExtensionMatchRegExp, usernameRegExp } from '../constants'
+import { emailRegExp, fileExtensionMatchRegExp, phoneNumberRegExp, usernameRegExp } from '../constants'
 
 /**
  * Function for validating user emails whether it's the right format or not.
@@ -29,6 +29,27 @@ export const validateUsername = (username: string): boolean => {
   }
 
   if (!usernameRegExp.test(username)) {
+    return false
+  }
+
+  return true
+}
+
+/**
+ * A function to validate simple phone number without spacebar and at least 4 digits, max 15 digits, will
+ * fail if the string contains any delimiters (` `, `\n`, `\t`)
+ *
+ * @see https://www.quora.com/What-is-maximum-and-minimum-length-of-any-mobile-number-across-the-world
+ *
+ * @param phoneNumber phone number string
+ * @returns boolean indicating whether the format is right
+ */
+export const validatePhoneNumber = (phoneNumber: string): boolean => {
+  if (phoneNumber.length < 4 || phoneNumber.length > 15) {
+    return false
+  }
+
+  if (!phoneNumberRegExp.test(phoneNumber)) {
     return false
   }
 

--- a/packages/common/test/validities.test.ts
+++ b/packages/common/test/validities.test.ts
@@ -1,8 +1,8 @@
 import t from 'tap'
 
-import { getFileExtension, validateEmail, validateUsername } from '../src/utils'
+import { getFileExtension, validateEmail, validatePhoneNumber, validateUsername } from '../src/utils'
 
-void t.test('Validate email formats', async t => {
+void t.test('validate email formats', async t => {
   t.strictSame(validateEmail('an_email@gmail.com'), true)
   t.strictSame(validateEmail('_another_email@gmail.com'), true)
   t.strictSame(validateEmail('this_is_hard@outlook.co.th'), true)
@@ -19,7 +19,7 @@ void t.test('Validate email formats', async t => {
   t.strictSame(validateEmail('abc-def@gmail#archive.com'), false)
 })
 
-void t.test('Validate username formats', async t => {
+void t.test('validate username formats', async t => {
   t.strictSame(validateUsername('a'), true)
   t.strictSame(validateUsername('abc'), true)
   t.strictSame(validateUsername('AbC'), true)
@@ -79,4 +79,17 @@ void t.test('validate file extensions', async t => {
   t.throws(() => {
     getFileExtension('render.md')
   }, 'unmatched file extension')
+})
+
+void t.test('validate phone numbers', async t => {
+  t.strictSame(validatePhoneNumber('943452365'), true)
+  t.strictSame(validatePhoneNumber('442352332444444444444423'), false)
+  t.strictSame(validatePhoneNumber('3984873334534244'), false)
+  t.strictSame(validatePhoneNumber('398487333453424'), true)
+  t.strictSame(validatePhoneNumber(' 4454545423'), false)
+  t.strictSame(validatePhoneNumber('445454 5423'), false)
+  t.strictSame(validatePhoneNumber('445454\n5423'), false)
+  t.strictSame(validatePhoneNumber('445454\t5423'), false)
+  t.strictSame(validatePhoneNumber('445454ก5423'), false)
+  t.strictSame(validatePhoneNumber('445454ndd5423'), false)
 })


### PR DESCRIPTION
## ✅ DoD / งานที่ทำ

- [x] All work is complete / ทุกอย่างเรียบร้อยดี
- [x] Issues linked: Resolves #170 

## 📝 Summary / สรุปผล

- ทำให้ `POST /auth/signup` ทำให้ต้องรับเบอร์โทรศัพท์ได้ (ใช้ข้อมูลในการบอกตำแหน่งผู้ใช้งาน)

## 💉 Testing / ทดสอบ

- `pnpm build` และ `pnpm test`

## 🛑 Problems / ปัญหา

- ยัง

## 💡 More ideas / ไอเดีย

ยังไม่มี

## 📸 Screenshots / ภาพถ่าย

ไม่มี
