### PR TITLE
make `GET /events/:eventId/seats` return `sectionId`

### DIFF
--- a/packages/backend/src/routes/events/get-event-seats.ts
+++ b/packages/backend/src/routes/events/get-event-seats.ts
@@ -67,10 +67,11 @@ export default async (instance: FastifyInstance, _: FastifyPluginOptions): Promi
         throw new Error('Event datetime not found')
       }
 
-      type EventSeats = Pick<event_sections, 'event_section_column_position' | 'event_section_row_position'> & Omit<event_seats, 'event_section_id'> & { is_seat_taken: boolean }
+      type EventSeats = Omit<event_sections, 'event_datetime_id'> & event_seats & { is_seat_taken: boolean }
 
       const sectionsAndSeats = await instance.pg.query<EventSeats, [events['event_id'], event_datetimes['event_datetime_id']]>(
         `select
+          event_sections.event_section_id,
           event_sections.event_section_row_position,
           event_sections.event_section_column_position,
           event_seats.event_seat_id,
@@ -92,6 +93,7 @@ export default async (instance: FastifyInstance, _: FastifyPluginOptions): Promi
       return {
         sections: sectionsAndSeats.rows.map(s => {
           return {
+            sectionId: s.event_section_id,
             sectionRowPosition: s.event_section_row_position,
             sectionColumnPosition: s.event_section_column_position,
             seatId: s.event_seat_id,

--- a/packages/backend/test/events/get-event-seats.test.ts
+++ b/packages/backend/test/events/get-event-seats.test.ts
@@ -245,6 +245,11 @@ void t.test('get sections and seats from the API', async t => {
           isSeatTaken: false
         }
       ])
+
+      // @ts-expect-error s being any
+      response.json().sections.forEach(s => {
+        t.type(s.sectionId, 'string')
+      })
     } catch (error) {
       t.error(error)
       t.fail()
@@ -311,6 +316,11 @@ void t.test('get sections and seats from the API', async t => {
           isSeatTaken: true
         }
       ])
+
+      // @ts-expect-error s being any
+      response.json().sections.forEach(s => {
+        t.type(s.sectionId, 'string')
+      })
     } catch (error) {
       t.error(error)
       t.fail()
@@ -363,6 +373,11 @@ void t.test('get sections and seats from the API', async t => {
           isSeatTaken: false
         }
       ])
+
+      // @ts-expect-error s being any
+      response.json().sections.forEach(s => {
+        t.type(s.sectionId, 'string')
+      })
     } catch (error) {
       t.error(error)
       t.fail()

--- a/packages/common/src/types/events.ts
+++ b/packages/common/src/types/events.ts
@@ -109,6 +109,7 @@ export type GetEventSeatsRequestQuerystring = Static<typeof GetEventSeatsRequest
 
 export const GetEventSeatsReplySchema = Type.Object({
   sections: Type.Array(Type.Object({
+    sectionId: Type.String(),
     sectionRowPosition: Type.Number(),
     sectionColumnPosition: Type.Number(),
     seatId: Type.String(),


### PR DESCRIPTION
## ✅ DoD / งานที่ทำ

- [x] All work is complete / ทุกอย่างเรียบร้อยดี
- [x] Issues linked: Resolves #267 

## ✔️ Checks

- [x] can you run `pnpm lint` without any errors? / รัน `pnpm lint` แล้วไม่มีเออเร่อ
- [x] can you run `pnpm lint:css` without any errors? / `pnpm lint:css` แล้วไม่มีเออเร่อ

## 📝 Summary / สรุปผล

- ทำให้ endpoint `GET /events/:eventId/seats` ส่ง sectionId กลับมา เพื่อนำไปยิง API ต่อไป

## 💉 Testing / ทดสอบ

- [x] can you run `pnpm test` without any errors? / รัน `pnpm test` แล้วไม่มีเออเร่อ
- [x] can you run `pnpm build -r` without any errors? / รัน `pnpm build -r` แล้วไม่มีเออเร่อ
- more tests / การทดสอบเพิ่มเติม

## 🛑 Problems / ปัญหา

- ไม่มี

## 💡 More ideas / ไอเดีย

ไม่มี

## 📸 Screenshots / ภาพถ่าย

ไม่มี
